### PR TITLE
libcutils/include:Remove the inclusion of cdefs from properties

### DIFF
--- a/libcutils/include/cutils/properties.h
+++ b/libcutils/include/cutils/properties.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <sys/cdefs.h>
 #include <stddef.h>
 #include <stdint.h>
 


### PR DESCRIPTION

## Summary

*Fix the compilation error when enabling QEMU in WAMR*

## Impact

*nop*

## Testing

*cd vela
./build.sh vendor/qemu/boards/vela/configs/goldfish-armeabi-v7a-ap
./build.sh menuconfig and enable following configs: INTERPRETERS_WAMR, INTERPRETERS_WAMR_AOT, INTERPRETERS_WAMR_CONFIGUABLE_BOUNDS_CHECKS, INTERPRETERS_WAMR_CUSTOM_NAME_SECTIONS, INTERPRETERS_WAMR_DUMP_CALL_STACK，INTERPRETERS_WAMR_LIBC_BUILTIN，INTERPRETERS_WAMR_LIB_PTHREAD，INTERPRETERS_WAMR_LOG，INTERPRETERS_WAMR_REF_TYPES，INTERPRETERS_WAMR_SHARED_MEMORY，INTERPRETERS_WAMR_STACKSIZE=32768，INTERPRETERS_WAMR_THREAD_MGR
Running with qemu
./emulator.sh vela*

